### PR TITLE
Fix typo on Less Pretty PDF

### DIFF
--- a/inst/rmarkdown/templates/character-sheet/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/character-sheet/skeleton/skeleton.Rmd
@@ -52,7 +52,7 @@ init = initBonus(char= char)
 
 c1 = c('Class \\& Level',
 	   'Race',
-	   'Backrground',
+	   'Background',
 	   'Alignment',
 	   'Proficiency') %>% boldify()
 


### PR DESCRIPTION
Less Pretty PDF shows `Backrground` instead of `Background`